### PR TITLE
fix #15: Compatibility with Openfire 5.0.0

### DIFF
--- a/changelog.html
+++ b/changelog.html
@@ -43,9 +43,9 @@
 PionTurn Plugin Changelog
 </h1>
 
-<p><b>1.0.1</b> -- April 2024</p>
+<p><b>1.0.1</b> -- (to be determined)</p>
 <ul>
-	<li></li>
+	<li>Fixed <a href="https://github.com/igniterealtime/openfire-pionturn-plugin/issues/15">Issue #15 - Openfire 5.0.0 compatibility</a></li>
 </ul>
 
 <p><b>1.0.0</b> -- March 2024 </p>

--- a/plugin.xml
+++ b/plugin.xml
@@ -6,8 +6,9 @@
     <description>${project.description}</description>
     <version>${project.version}</version>
     <licenseType>Apache 2.0</licenseType>
-    <date>2025-03-31</date>
+    <date>2025-06-15</date>
     <minServerVersion>4.0.0</minServerVersion>
+    <minJavaVersion>1.8</minJavaVersion>
 
    <adminconsole>
         <tab id="sidebar-media-services">

--- a/src/java/org/igniterealtime/openfire/plugins/externalservicediscovery/Service.java
+++ b/src/java/org/igniterealtime/openfire/plugins/externalservicediscovery/Service.java
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Ignite Realtime Foundation. All rights reserved.
+ * Copyright (C) 2017-2025 Ignite Realtime Foundation. All rights reserved.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -17,7 +17,6 @@ package org.igniterealtime.openfire.plugins.externalservicediscovery;
 
 import org.jivesoftware.database.JiveID;
 import org.jivesoftware.database.SequenceManager;
-import org.jivesoftware.util.StringUtils;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 import org.xmpp.packet.JID;
@@ -29,6 +28,7 @@ import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.security.InvalidKeyException;
 import java.security.NoSuchAlgorithmException;
+import java.util.Base64;
 import java.util.Date;
 
 /**
@@ -327,7 +327,7 @@ public final class Service
                 final Mac mac = Mac.getInstance( "HmacSHA1" );
                 mac.init( secretKey );
                 final byte[] nonce = mac.doFinal( username.getBytes( StandardCharsets.UTF_8 ) );
-                password = StringUtils.encodeBase64( nonce );
+                password = Base64.getEncoder().encodeToString( nonce );
             }
             catch ( InvalidKeyException | NoSuchAlgorithmException e )
             {


### PR DESCRIPTION
This replaces a custom implementation for Base64 encoding with one provided by Java.

In Openfire 5.0.0, the custom implementation is removed. With this change, the plugin is compatible with Openfire 5.0.0 (but also earlier versions).